### PR TITLE
Add inactivity carousel

### DIFF
--- a/TrabCurso/public/FrontAddons/CSS/main/main.css
+++ b/TrabCurso/public/FrontAddons/CSS/main/main.css
@@ -386,3 +386,23 @@ footer {
         padding: 15px;
     }
 }
+
+/* Overlay do carrossel de promoções */
+.carousel-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    cursor: pointer;
+}
+
+.carousel-overlay img {
+    max-width: 80%;
+    max-height: 80%;
+}

--- a/TrabCurso/public/FrontAddons/JS/main/carousel.js
+++ b/TrabCurso/public/FrontAddons/JS/main/carousel.js
@@ -1,0 +1,45 @@
+// Carousel and inactivity handler
+const INACTIVITY_DELAY = 20000; // 20 seconds
+const PROMO_IMAGES = [
+    '/FrontAddons/IMG/ImagemHamburguerimg.jpg'
+];
+
+let inactivityTimer;
+
+function startTimer() {
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(showCarousel, INACTIVITY_DELAY);
+}
+
+function showCarousel() {
+    const overlay = document.getElementById('carousel-overlay');
+    if (!overlay) return;
+    overlay.style.display = 'flex';
+    let index = 0;
+    const img = overlay.querySelector('img');
+    if (img) img.src = PROMO_IMAGES[index];
+    const interval = setInterval(() => {
+        index = (index + 1) % PROMO_IMAGES.length;
+        if (img) img.src = PROMO_IMAGES[index];
+    }, 3000);
+
+    function close() {
+        overlay.style.display = 'none';
+        window.location.href = '/';
+        clearInterval(interval);
+        overlay.removeEventListener('click', close);
+    }
+
+    overlay.addEventListener('click', close);
+}
+
+function resetTimer() {
+    startTimer();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    ['mousemove', 'mousedown', 'keydown', 'touchstart'].forEach(evt => {
+        document.addEventListener(evt, resetTimer);
+    });
+    startTimer();
+});

--- a/TrabCurso/public/index.html
+++ b/TrabCurso/public/index.html
@@ -52,7 +52,11 @@
         </footer>
     </div>
 
+    <div id="carousel-overlay" class="carousel-overlay" style="display:none;">
+        <img src="" alt="Promoção" />
+    </div>
     <script type="module" src="/FrontAddons/JS/main/main.js"></script>
+    <script type="module" src="/FrontAddons/JS/main/carousel.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- show promotional carousel on 20s inactivity
- add overlay container in the homepage
- style carousel overlay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686cb552985483249826e59a042cfe07